### PR TITLE
Improve permission guidance for global hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ make run
 ```bash
 make build          # Debug build
 make build-release  # Release build
-make test           # Run unit tests (43 tests)
+make test           # Run unit tests
 make benchmark      # Run performance benchmarks
 make run            # Build and run
 make clean          # Clean build artifacts
@@ -166,8 +166,11 @@ Talk learns from your corrections to improve future polishing.
 
 On first launch, you need to grant:
 
-1. **Microphone** — macOS will prompt automatically
-2. **Accessibility** — Manually add Talk.app in System Settings → Privacy & Security → Accessibility
+1. **Microphone** — Required for recording. macOS will prompt automatically.
+2. **Input Monitoring** — Required for the global hotkey. Enable Talk in System Settings → Privacy & Security → Input Monitoring.
+3. **Accessibility** — Required for auto-pasting text into other apps. Enable Talk in System Settings → Privacy & Security → Accessibility.
+
+If the global hotkey does not respond, check **Input Monitoring** first. After enabling it, quit and relaunch Talk so the hotkey listener can work reliably.
 
 ## Development
 
@@ -182,7 +185,7 @@ open Talk.xcodeproj
 ### Testing
 
 ```bash
-make test       # 43 unit tests (HotKeyCombo, AppSettings, AudioDevice, FloatingIndicator, VocabularyManager)
+make test       # Unit tests
 make benchmark  # Performance benchmarks (ASR/LLM load, inference, pipeline, memory)
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -96,7 +96,7 @@ make run
 ```bash
 make build          # Debug 构建
 make build-release  # Release 构建
-make test           # 运行单元测试（43 个）
+make test           # 运行单元测试
 make benchmark      # 运行性能基准测试
 make run            # 构建并运行
 make clean          # 清理构建产物
@@ -166,8 +166,11 @@ Talk 会从你的修改中学习，持续改进润色质量。
 
 首次运行需要授权：
 
-1. **麦克风** — 系统自动弹出授权请求
-2. **辅助功能** — 需手动在「系统设置 → 隐私与安全性 → 辅助功能」中添加 Talk.app
+1. **麦克风** — 用于录音，系统会自动弹出授权请求
+2. **输入监控** — 用于监听全局快捷键。请在「系统设置 → 隐私与安全性 → 输入监控」中打开 Talk
+3. **辅助功能** — 用于自动粘贴文本到其他应用。请在「系统设置 → 隐私与安全性 → 辅助功能」中打开 Talk.app
+
+如果全局快捷键没有反应，优先检查 **输入监控**。开启输入监控后，需要退出并重新打开 Talk，热键才会稳定生效。
 
 ## 开发
 
@@ -182,7 +185,7 @@ open Talk.xcodeproj
 ### 测试
 
 ```bash
-make test       # 43 个单元测试（HotKeyCombo、AppSettings、AudioDevice、FloatingIndicator、VocabularyManager）
+make test       # 单元测试
 make benchmark  # 性能基准测试（ASR/LLM 加载、推理、管线、内存）
 ```
 

--- a/Talk/UI/OnboardingView.swift
+++ b/Talk/UI/OnboardingView.swift
@@ -103,8 +103,7 @@ private struct WelcomeStep: View {
 private struct PermissionsStep: View {
     var onNext: () -> Void
 
-    @State private var micGranted = false
-    @State private var accessibilityGranted = false
+    @State private var permissions = PermissionsSnapshot.empty
     @State private var pollTimer: Timer?
 
     var body: some View {
@@ -115,80 +114,39 @@ private struct PermissionsStep: View {
                 .font(.title2)
                 .fontWeight(.semibold)
 
-            Text("Talk 需要以下权限才能正常工作")
+            Text("Talk 需要以下权限才能完整工作")
                 .font(.body)
                 .foregroundColor(.secondary)
 
-            // Microphone permission
             GroupBox {
-                HStack(spacing: 12) {
-                    Image(systemName: "mic.circle")
-                        .font(.system(size: 32))
-                        .foregroundStyle(.blue)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("麦克风权限")
-                            .font(.headline)
-                        Text("Talk 需要录制你的语音，音频仅在本地处理，不会上传任何服务器。")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-
-                    Spacer()
-
-                    if micGranted {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 24))
-                            .foregroundStyle(.green)
-                    } else {
-                        Button("授权麦克风") {
-                            requestMicrophoneAccess()
-                        }
-                        .controlSize(.small)
-                    }
-                }
-                .padding(4)
+                PermissionRowView(
+                    permission: .microphone,
+                    isGranted: permissions.microphoneGranted,
+                    actionTitle: microphoneActionTitle,
+                    action: handleMicrophoneAction
+                )
             }
             .padding(.horizontal, 24)
 
-            // Accessibility permission
             GroupBox {
-                HStack(spacing: 12) {
-                    Image(systemName: "hand.raised.circle")
-                        .font(.system(size: 32))
-                        .foregroundStyle(.orange)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("辅助功能权限")
-                            .font(.headline)
-                        Text("Talk 需要辅助功能权限来将文字自动粘贴到当前应用。请在系统设置中手动授予。")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-
-                    Spacer()
-
-                    if accessibilityGranted {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 24))
-                            .foregroundStyle(.green)
-                    } else {
-                        Button("打开设置") {
-                            openAccessibilitySettings()
-                        }
-                        .controlSize(.small)
-                    }
-                }
-                .padding(4)
+                PermissionRowView(
+                    permission: .inputMonitoring,
+                    isGranted: permissions.inputMonitoringGranted,
+                    actionTitle: "打开设置",
+                    action: openInputMonitoringSettings
+                )
             }
             .padding(.horizontal, 24)
 
-            if !accessibilityGranted {
-                Text("在「系统设置 → 隐私与安全性 → 辅助功能」中添加 Talk 并打开开关。")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 40)
+            GroupBox {
+                PermissionRowView(
+                    permission: .accessibility,
+                    isGranted: permissions.accessibilityGranted,
+                    actionTitle: "打开设置",
+                    action: openAccessibilitySettings
+                )
             }
+            .padding(.horizontal, 24)
 
             Spacer()
 
@@ -204,14 +162,13 @@ private struct PermissionsStep: View {
                 }
                 .controlSize(.large)
                 .buttonStyle(.borderedProminent)
-                .disabled(!micGranted)
+                .disabled(!permissions.microphoneGranted)
             }
             .padding(.bottom, 24)
         }
         .onAppear {
-            checkMicrophoneStatus()
-            checkAccessibilityStatus()
-            startAccessibilityPolling()
+            refreshPermissions()
+            startPermissionPolling()
         }
         .onDisappear {
             pollTimer?.invalidate()
@@ -219,33 +176,37 @@ private struct PermissionsStep: View {
         }
     }
 
-    private func requestMicrophoneAccess() {
-        AVCaptureDevice.requestAccess(for: .audio) { granted in
-            DispatchQueue.main.async {
-                micGranted = granted
+    private var microphoneActionTitle: String {
+        AVCaptureDevice.authorizationStatus(for: .audio) == .notDetermined ? "授权麦克风" : "打开设置"
+    }
+
+    private func handleMicrophoneAction() {
+        if AVCaptureDevice.authorizationStatus(for: .audio) == .notDetermined {
+            PermissionManager.requestMicrophoneAccess { _ in
+                refreshPermissions()
             }
+        } else {
+            PermissionManager.openSettings(for: .microphone)
         }
     }
 
-    private func checkMicrophoneStatus() {
-        let status = AVCaptureDevice.authorizationStatus(for: .audio)
-        micGranted = status == .authorized
-    }
-
-    private func checkAccessibilityStatus() {
-        accessibilityGranted = AXIsProcessTrusted()
+    private func openInputMonitoringSettings() {
+        _ = PermissionManager.requestInputMonitoringAccessIfNeeded()
+        PermissionManager.openSettings(for: .inputMonitoring)
     }
 
     private func openAccessibilitySettings() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
-            NSWorkspace.shared.open(url)
-        }
+        PermissionManager.openSettings(for: .accessibility)
     }
 
-    private func startAccessibilityPolling() {
+    private func refreshPermissions() {
+        permissions = PermissionManager.snapshot()
+    }
+
+    private func startPermissionPolling() {
         pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
             DispatchQueue.main.async {
-                accessibilityGranted = AXIsProcessTrusted()
+                refreshPermissions()
             }
         }
     }
@@ -426,6 +387,7 @@ private struct HotkeyStep: View {
 private struct ReadyStep: View {
     @Bindable var settings: AppSettings
     var onComplete: () -> Void
+    @State private var permissions = PermissionsSnapshot.empty
 
     var body: some View {
         VStack(spacing: 20) {
@@ -459,6 +421,14 @@ private struct ReadyStep: View {
                     .foregroundColor(.secondary)
             }
 
+            if !permissions.allRequiredGranted {
+                Text(missingPermissionsSummary)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
             Spacer()
 
             Button(action: onComplete) {
@@ -476,5 +446,24 @@ private struct ReadyStep: View {
             .font(.caption)
             .padding(.bottom, 24)
         }
+        .onAppear {
+            permissions = PermissionManager.snapshot()
+        }
+    }
+
+    private var missingPermissionsSummary: String {
+        var items: [String] = []
+
+        if !permissions.microphoneGranted {
+            items.append("麦克风")
+        }
+        if !permissions.inputMonitoringGranted {
+            items.append("输入监控（全局快捷键）")
+        }
+        if !permissions.accessibilityGranted {
+            items.append("辅助功能（自动粘贴）")
+        }
+
+        return "仍有权限未完成：\(items.joined(separator: "、"))。可稍后在设置 → 高级 → 权限中完成。"
     }
 }

--- a/Talk/UI/PermissionRowView.swift
+++ b/Talk/UI/PermissionRowView.swift
@@ -1,0 +1,63 @@
+//
+//  PermissionRowView.swift
+//  Talk
+//
+//  通用权限状态行
+//
+
+import SwiftUI
+
+struct PermissionRowView: View {
+    let permission: AppPermission
+    let isGranted: Bool
+    let actionTitle: String
+    let action: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                Image(systemName: permission.iconName)
+                    .font(.system(size: 32))
+                    .foregroundStyle(iconColor)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(permission.title)
+                        .font(.headline)
+                    Text(permission.detail)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if isGranted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.green)
+                } else {
+                    Button(actionTitle, action: action)
+                        .controlSize(.small)
+                }
+            }
+
+            if let restartHint = permission.restartHint, !isGranted {
+                Text(restartHint)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.leading, 44)
+            }
+        }
+        .padding(4)
+    }
+
+    private var iconColor: Color {
+        switch permission {
+        case .microphone:
+            return .blue
+        case .inputMonitoring:
+            return .indigo
+        case .accessibility:
+            return .orange
+        }
+    }
+}

--- a/Talk/UI/SettingsView.swift
+++ b/Talk/UI/SettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AVFoundation
 
 struct SettingsView: View {
     @Bindable private var settings = AppSettings.shared
@@ -62,6 +63,10 @@ private struct RecordingSettingsTab: View {
                     settings.save()
                     AppDelegate.shared?.applyHotKey(newCombo, triggerMode: settings.recordingTriggerMode)
                 }
+
+                Text("全局快捷键依赖输入监控权限。若快捷键无反应，请在系统设置 → 隐私与安全性 → 输入监控中开启 Talk，并重启应用。")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
 
                 HStack {
                     Text("录音时长限制")
@@ -402,9 +407,24 @@ private struct OutputSettingsTab: View {
 private struct AdvancedSettingsTab: View {
     @Bindable var settings: AppSettings
     @State private var showVocabularyView = false
+    @State private var permissions = PermissionsSnapshot.empty
+    @State private var pollTimer: Timer?
 
     var body: some View {
         Form {
+            Section {
+                ForEach(AppPermission.allCases) { permission in
+                    PermissionRowView(
+                        permission: permission,
+                        isGranted: permissions.isGranted(permission),
+                        actionTitle: actionTitle(for: permission),
+                        action: { handlePermissionAction(permission) }
+                    )
+                }
+            } header: {
+                Text("权限")
+            }
+
             Section {
                 Picker("选中文本捕获方式", selection: $settings.selectionCaptureMethod) {
                     Text("Accessibility API（低侵入）").tag(AppSettings.SelectionCaptureMethod.accessibility)
@@ -517,8 +537,51 @@ private struct AdvancedSettingsTab: View {
             }
         }
         .formStyle(.grouped)
+        .onAppear {
+            refreshPermissions()
+            startPermissionPolling()
+        }
+        .onDisappear {
+            pollTimer?.invalidate()
+            pollTimer = nil
+        }
         .sheet(isPresented: $showVocabularyView) {
             VocabularyView()
+        }
+    }
+
+    private func actionTitle(for permission: AppPermission) -> String {
+        guard permission == .microphone else { return "打开设置" }
+        return AVCaptureDevice.authorizationStatus(for: .audio) == .notDetermined ? "授权麦克风" : "打开设置"
+    }
+
+    private func handlePermissionAction(_ permission: AppPermission) {
+        switch permission {
+        case .microphone:
+            if AVCaptureDevice.authorizationStatus(for: .audio) == .notDetermined {
+                PermissionManager.requestMicrophoneAccess { _ in
+                    refreshPermissions()
+                }
+            } else {
+                PermissionManager.openSettings(for: .microphone)
+            }
+        case .inputMonitoring:
+            _ = PermissionManager.requestInputMonitoringAccessIfNeeded()
+            PermissionManager.openSettings(for: .inputMonitoring)
+        case .accessibility:
+            PermissionManager.openSettings(for: .accessibility)
+        }
+    }
+
+    private func refreshPermissions() {
+        permissions = PermissionManager.snapshot()
+    }
+
+    private func startPermissionPolling() {
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
+            DispatchQueue.main.async {
+                refreshPermissions()
+            }
         }
     }
 }

--- a/Talk/Utils/PermissionManager.swift
+++ b/Talk/Utils/PermissionManager.swift
@@ -1,0 +1,146 @@
+//
+//  PermissionManager.swift
+//  Talk
+//
+//  系统权限检测与设置跳转
+//
+
+import Foundation
+import AppKit
+import AVFoundation
+import ApplicationServices
+import CoreGraphics
+
+enum AppPermission: CaseIterable, Identifiable {
+    case microphone
+    case inputMonitoring
+    case accessibility
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .microphone:
+            return "麦克风权限"
+        case .inputMonitoring:
+            return "输入监控"
+        case .accessibility:
+            return "辅助功能权限"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .microphone:
+            return "Talk 需要录制你的语音，音频仅在本地处理。"
+        case .inputMonitoring:
+            return "Talk 需要输入监控权限来监听全局快捷键。"
+        case .accessibility:
+            return "Talk 需要辅助功能权限来将文字自动粘贴到当前应用。"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .microphone:
+            return "mic.circle"
+        case .inputMonitoring:
+            return "keyboard"
+        case .accessibility:
+            return "hand.raised.circle"
+        }
+    }
+
+    var settingsURL: URL {
+        let path: String
+        switch self {
+        case .microphone:
+            path = "Privacy_Microphone"
+        case .inputMonitoring:
+            path = "Privacy_ListenEvent"
+        case .accessibility:
+            path = "Privacy_Accessibility"
+        }
+
+        return URL(string: "x-apple.systempreferences:com.apple.preference.security?\(path)")!
+    }
+
+    var restartHint: String? {
+        guard self == .inputMonitoring else { return nil }
+        return "开启后请退出并重新打开 Talk，全局快捷键才会生效。"
+    }
+}
+
+protocol PermissionStatusProviding {
+    func isMicrophoneGranted() -> Bool
+    func isInputMonitoringGranted() -> Bool
+    func isAccessibilityGranted() -> Bool
+}
+
+struct LivePermissionStatusProvider: PermissionStatusProviding {
+    func isMicrophoneGranted() -> Bool {
+        AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+    }
+
+    func isInputMonitoringGranted() -> Bool {
+        CGPreflightListenEventAccess()
+    }
+
+    func isAccessibilityGranted() -> Bool {
+        AXIsProcessTrusted()
+    }
+}
+
+struct PermissionsSnapshot: Equatable {
+    var microphoneGranted: Bool
+    var inputMonitoringGranted: Bool
+    var accessibilityGranted: Bool
+
+    static let empty = PermissionsSnapshot(
+        microphoneGranted: false,
+        inputMonitoringGranted: false,
+        accessibilityGranted: false
+    )
+
+    func isGranted(_ permission: AppPermission) -> Bool {
+        switch permission {
+        case .microphone:
+            return microphoneGranted
+        case .inputMonitoring:
+            return inputMonitoringGranted
+        case .accessibility:
+            return accessibilityGranted
+        }
+    }
+
+    var allRequiredGranted: Bool {
+        microphoneGranted && inputMonitoringGranted && accessibilityGranted
+    }
+}
+
+enum PermissionManager {
+    static func snapshot(statusProvider: PermissionStatusProviding = LivePermissionStatusProvider()) -> PermissionsSnapshot {
+        PermissionsSnapshot(
+            microphoneGranted: statusProvider.isMicrophoneGranted(),
+            inputMonitoringGranted: statusProvider.isInputMonitoringGranted(),
+            accessibilityGranted: statusProvider.isAccessibilityGranted()
+        )
+    }
+
+    static func requestMicrophoneAccess(completion: @escaping (Bool) -> Void) {
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
+            DispatchQueue.main.async {
+                completion(granted)
+            }
+        }
+    }
+
+    static func requestInputMonitoringAccessIfNeeded() -> Bool {
+        guard !CGPreflightListenEventAccess() else { return true }
+        return CGRequestListenEventAccess()
+    }
+
+    static func openSettings(for permission: AppPermission) {
+        NSWorkspace.shared.open(permission.settingsURL)
+    }
+}

--- a/TalkTests/PermissionManagerTests.swift
+++ b/TalkTests/PermissionManagerTests.swift
@@ -1,0 +1,53 @@
+//
+//  PermissionManagerTests.swift
+//  TalkTests
+//
+//  Permission manager unit tests using Swift Testing framework
+//
+
+import Testing
+@testable import Talk
+
+struct PermissionManagerTests {
+    private struct MockPermissionStatusProvider: PermissionStatusProviding {
+        let microphoneGranted: Bool
+        let inputMonitoringGranted: Bool
+        let accessibilityGranted: Bool
+
+        func isMicrophoneGranted() -> Bool { microphoneGranted }
+        func isInputMonitoringGranted() -> Bool { inputMonitoringGranted }
+        func isAccessibilityGranted() -> Bool { accessibilityGranted }
+    }
+
+    @Test func snapshotRequiresInputMonitoringForFullReadiness() {
+        let snapshot = PermissionManager.snapshot(statusProvider: MockPermissionStatusProvider(
+            microphoneGranted: true,
+            inputMonitoringGranted: false,
+            accessibilityGranted: true
+        ))
+
+        #expect(snapshot.microphoneGranted == true)
+        #expect(snapshot.inputMonitoringGranted == false)
+        #expect(snapshot.accessibilityGranted == true)
+        #expect(snapshot.allRequiredGranted == false)
+    }
+
+    @Test func snapshotIsReadyWhenAllPermissionsGranted() {
+        let snapshot = PermissionManager.snapshot(statusProvider: MockPermissionStatusProvider(
+            microphoneGranted: true,
+            inputMonitoringGranted: true,
+            accessibilityGranted: true
+        ))
+
+        #expect(snapshot.allRequiredGranted == true)
+        #expect(snapshot.isGranted(.microphone) == true)
+        #expect(snapshot.isGranted(.inputMonitoring) == true)
+        #expect(snapshot.isGranted(.accessibility) == true)
+    }
+
+    @Test func inputMonitoringMetadataIncludesRestartGuidance() {
+        #expect(AppPermission.inputMonitoring.title == "输入监控")
+        #expect(AppPermission.inputMonitoring.settingsURL.absoluteString.contains("Privacy_ListenEvent"))
+        #expect(AppPermission.inputMonitoring.restartHint == "开启后请退出并重新打开 Talk，全局快捷键才会生效。")
+    }
+}

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -30,7 +30,7 @@ Talk 首次启动时展示引导流程，帮助用户完成权限授予、模型
 
 **界面内容：**
 
-两个权限项，各占一行，左侧图标 + 说明文字，右侧状态标记（未授权 / 已授权 checkmark）。
+三个权限项，各占一行，左侧图标 + 说明文字，右侧状态标记（未授权 / 已授权 checkmark）。
 
 #### 2a. 麦克风权限
 
@@ -41,7 +41,22 @@ Talk 首次启动时展示引导流程，帮助用户完成权限授予、模型
 - 行为：调用 `AVCaptureDevice.requestAccess(for: .audio)`，macOS 弹出系统授权弹窗
 - 授权后：按钮变为绿色 checkmark + "已授权"
 
-#### 2b. 辅助功能权限
+#### 2b. 输入监控权限
+
+- 图标：`keyboard`
+- 标题："输入监控"
+- 说明："Talk 需要输入监控权限来监听全局快捷键。没有这项权限时，菜单栏录音可用，但快捷键可能没有反应。"
+- 操作指引（折叠/展开，默认展开）：
+  1. 点击下方按钮打开系统设置
+  2. 在「隐私与安全性 → 输入监控」列表中找到 Talk
+  3. 打开 Talk 右侧的开关
+  4. **退出并重新打开 Talk**
+  5. 回到 Talk，状态会自动更新
+- 按钮：`打开输入监控设置`
+- 行为：调用 `NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")!)`
+- 检测逻辑：用定时器（每 2 秒）轮询 `CGPreflightListenEventAccess()`，授权后显示 checkmark
+
+#### 2c. 辅助功能权限
 
 - 图标：`hand.raised.circle`
 - 标题："辅助功能权限"
@@ -58,12 +73,13 @@ Talk 首次启动时展示引导流程，帮助用户完成权限授予、模型
 
 **底部按钮：**
 
-- `下一步` —— 两项都已授权时高亮
+- `下一步` —— 麦克风已授权时高亮
 - `稍后设置` —— 始终可点，跳到 Step 3（缺少权限不影响模型下载）
 
 **技术说明：**
 
 - 麦克风权限状态通过 `AVCaptureDevice.authorizationStatus(for: .audio)` 检查
+- 输入监控权限状态通过 `CGPreflightListenEventAccess()` 检查
 - 辅助功能权限状态通过 `AXIsProcessTrusted()` 检查
 - 页面出现时立即检查当前状态，已授权的项直接显示 checkmark
 
@@ -131,6 +147,7 @@ Talk 首次启动时展示引导流程，帮助用户完成权限授予、模型
 - 当前快捷键显示区域，带录制功能（复用现有 `KeyRecorderView` 组件）
 - 默认值：`⌃ Control`
 - 点击后进入录制模式，按下新键即完成设置
+- 快捷键区域下方显示说明："全局快捷键依赖输入监控权限。若快捷键无反应，请先打开输入监控并重启 Talk。"
 
 #### 触发方式
 


### PR DESCRIPTION
## Summary
- add a small shared permission layer for microphone, Input Monitoring, and Accessibility
- update onboarding to explain that global hotkeys depend on Input Monitoring and that enabling it requires relaunching Talk
- add a permissions section in Settings and sync the README / onboarding docs with the same guidance

## Testing
- this fork has not been truly tested end-to-end
- `make test` could not be completed in this environment because `xcode-select` points to `/Library/Developer/CommandLineTools` and there is no full Xcode-backed `xcodebuild` available
- only static review and lightweight local validation were done before opening this PR