### PR TITLE
feat: total characters tracking & time-saved estimation

### DIFF
--- a/Talk/Models/UsageStatistics.swift
+++ b/Talk/Models/UsageStatistics.swift
@@ -19,6 +19,7 @@ struct DailyStats: Codable, Identifiable {
     var llmInferenceTime: TimeInterval = 0        // LLM 推理总时长
     var editCount: Int = 0              // 用户编辑次数
     var errorCount: Int = 0             // 错误次数
+    var totalCharacters: Int = 0              // 总输出字符数
     
     /// 平均每次使用时长
     var averageSessionDuration: TimeInterval {
@@ -33,6 +34,20 @@ struct DailyStats: Codable, Identifiable {
     init(id: UUID = UUID(), date: Date = Date()) {
         self.id = id
         self.date = Calendar.current.startOfDay(for: date)
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        date = try container.decode(Date.self, forKey: .date)
+        sessionCount = try container.decode(Int.self, forKey: .sessionCount)
+        totalRecordingDuration = try container.decode(TimeInterval.self, forKey: .totalRecordingDuration)
+        totalProcessingTime = try container.decode(TimeInterval.self, forKey: .totalProcessingTime)
+        asrInferenceTime = try container.decode(TimeInterval.self, forKey: .asrInferenceTime)
+        llmInferenceTime = try container.decode(TimeInterval.self, forKey: .llmInferenceTime)
+        editCount = try container.decode(Int.self, forKey: .editCount)
+        errorCount = try container.decode(Int.self, forKey: .errorCount)
+        totalCharacters = try container.decodeIfPresent(Int.self, forKey: .totalCharacters) ?? 0
     }
 }
 
@@ -134,6 +149,7 @@ final public class UsageStatisticsManager {
         processingTime: TimeInterval,
         asrTime: TimeInterval,
         llmTime: TimeInterval,
+        characterCount: Int = 0,
         hadError: Bool = false
     ) {
         let today = Calendar.current.startOfDay(for: Date())
@@ -149,6 +165,7 @@ final public class UsageStatisticsManager {
             if hadError {
                 dailyStats[index].errorCount += 1
             }
+            dailyStats[index].totalCharacters += characterCount
             logger.debug("更新了今天的统计记录")
         } else {
             // 创建新记录
@@ -159,6 +176,7 @@ final public class UsageStatisticsManager {
             newDay.asrInferenceTime = asrTime
             newDay.llmInferenceTime = llmTime
             newDay.errorCount = hadError ? 1 : 0
+            newDay.totalCharacters = characterCount
             dailyStats.append(newDay)
             logger.info("创建了新的统计记录")
         }

--- a/Talk/Models/UsageStatistics.swift
+++ b/Talk/Models/UsageStatistics.swift
@@ -61,15 +61,20 @@ struct AggregateStats {
     let averageEditRate: Double
     let averageErrorRate: Double
 
-    /// 格式化总时长
-    var totalDurationFormatted: String {
-        let hours = Int(totalDuration) / 3600
-        let minutes = (Int(totalDuration) % 3600) / 60
+    /// 格式化时长为 "X 小时 Y 分钟" 或 "Y 分钟"
+    static func formatDuration(_ duration: TimeInterval) -> String {
+        let hours = Int(duration) / 3600
+        let minutes = (Int(duration) % 3600) / 60
         if hours > 0 {
             return String(localized: "\(hours) 小时\(minutes) 分钟")
         } else {
             return String(localized: "\(minutes) 分钟")
         }
+    }
+
+    /// 格式化总时长
+    var totalDurationFormatted: String {
+        Self.formatDuration(totalDuration)
     }
 
     /// 估算节省时间（打字 100 字/分钟 vs 实际录音时长）
@@ -80,13 +85,7 @@ struct AggregateStats {
 
     /// 格式化节省时间
     var estimatedTimeSavedFormatted: String {
-        let hours = Int(estimatedTimeSaved) / 3600
-        let minutes = (Int(estimatedTimeSaved) % 3600) / 60
-        if hours > 0 {
-            return String(localized: "\(hours) 小时\(minutes) 分钟")
-        } else {
-            return String(localized: "\(minutes) 分钟")
-        }
+        Self.formatDuration(estimatedTimeSaved)
     }
 }
 

--- a/Talk/Models/UsageStatistics.swift
+++ b/Talk/Models/UsageStatistics.swift
@@ -55,15 +55,33 @@ struct DailyStats: Codable, Identifiable {
 struct AggregateStats {
     let totalSessions: Int
     let totalDuration: TimeInterval
+    let totalCharacters: Int
     let totalEdits: Int
     let totalErrors: Int
     let averageEditRate: Double
     let averageErrorRate: Double
-    
+
     /// 格式化总时长
     var totalDurationFormatted: String {
         let hours = Int(totalDuration) / 3600
         let minutes = (Int(totalDuration) % 3600) / 60
+        if hours > 0 {
+            return String(localized: "\(hours) 小时\(minutes) 分钟")
+        } else {
+            return String(localized: "\(minutes) 分钟")
+        }
+    }
+
+    /// 估算节省时间（打字 100 字/分钟 vs 实际录音时长）
+    var estimatedTimeSaved: TimeInterval {
+        let typingTime = Double(totalCharacters) / 100.0 * 60.0
+        return max(0, typingTime - totalDuration)
+    }
+
+    /// 格式化节省时间
+    var estimatedTimeSavedFormatted: String {
+        let hours = Int(estimatedTimeSaved) / 3600
+        let minutes = (Int(estimatedTimeSaved) % 3600) / 60
         if hours > 0 {
             return String(localized: "\(hours) 小时\(minutes) 分钟")
         } else {
@@ -224,12 +242,14 @@ final public class UsageStatisticsManager {
     func getAggregateStats() -> AggregateStats {
         let totalSessions = dailyStats.reduce(0) { $0 + $1.sessionCount }
         let totalDuration = dailyStats.reduce(0) { $0 + $1.totalRecordingDuration }
+        let totalCharacters = dailyStats.reduce(0) { $0 + $1.totalCharacters }
         let totalEdits = dailyStats.reduce(0) { $0 + $1.editCount }
         let totalErrors = dailyStats.reduce(0) { $0 + $1.errorCount }
-        
+
         return AggregateStats(
             totalSessions: totalSessions,
             totalDuration: totalDuration,
+            totalCharacters: totalCharacters,
             totalEdits: totalEdits,
             totalErrors: totalErrors,
             averageEditRate: totalSessions > 0 ? Double(totalEdits) / Double(totalSessions) : 0,

--- a/Talk/TalkApp.swift
+++ b/Talk/TalkApp.swift
@@ -847,6 +847,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                     processingTime: CFAbsoluteTimeGetCurrent() - processingStart,
                     asrTime: 0,
                     llmTime: llmInferenceTime,
+                    characterCount: polishedText.count,
                     hadError: false
                 )
                 if self.pendingEngineReload {
@@ -1033,6 +1034,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                     processingTime: CFAbsoluteTimeGetCurrent() - processingStart,
                     asrTime: asrInferenceTime,
                     llmTime: llmInferenceTime,
+                    characterCount: polishedText.count,
                     hadError: false
                 )
                 if self.pendingEngineReload {

--- a/Talk/UI/SettingsView+Statistics.swift
+++ b/Talk/UI/SettingsView+Statistics.swift
@@ -11,13 +11,7 @@ import SwiftUI
 struct StatisticsView: View {
     @ObservationIgnored
     private let statsManager = UsageStatisticsManager.shared
-    
-    private let numberFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter
-    }()
-    
+
     var body: some View {
         // Match the other settings tabs (RecordingSettingsTab, ASRSettingsTab,
         // …) which use Form{} as the top-level container — Form gives consistent
@@ -104,9 +98,7 @@ struct OverviewSection: View {
     }
 
     private func formatCharacterCount(_ count: Int) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: count)) ?? "\(count)"
+        count.formatted(.number)
     }
 }
 

--- a/Talk/UI/SettingsView+Statistics.swift
+++ b/Talk/UI/SettingsView+Statistics.swift
@@ -59,36 +59,54 @@ struct OverviewSection: View {
     let stats: AggregateStats
 
     var body: some View {
-        HStack(spacing: 12) {
-            StatCard(
-                title: String(localized: "总使用次数"),
-                value: "\(stats.totalSessions)",
-                icon: "mic.fill",
-                color: .blue
-            )
-
-            StatCard(
-                title: String(localized: "总录音时长"),
-                value: stats.totalDurationFormatted,
-                icon: "clock.fill",
-                color: .green
-            )
-
-            StatCard(
-                title: String(localized: "编辑率"),
-                value: String(format: "%.1f%%", stats.averageEditRate * 100),
-                icon: "pencil.tip.crop.circle",
-                color: .orange
-            )
-
-            StatCard(
-                title: String(localized: "错误率"),
-                value: String(format: "%.1f%%", stats.averageErrorRate * 100),
-                icon: "exclamationmark.triangle.fill",
-                color: .red
-            )
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                StatCard(
+                    title: String(localized: "总使用次数"),
+                    value: "\(stats.totalSessions)",
+                    icon: "mic.fill",
+                    color: .blue
+                )
+                StatCard(
+                    title: String(localized: "总输入字数"),
+                    value: formatCharacterCount(stats.totalCharacters),
+                    icon: "text.cursor",
+                    color: .purple
+                )
+                StatCard(
+                    title: String(localized: "累计节省时间"),
+                    value: stats.estimatedTimeSavedFormatted,
+                    icon: "bolt.fill",
+                    color: .yellow
+                )
+            }
+            HStack(spacing: 12) {
+                StatCard(
+                    title: String(localized: "总录音时长"),
+                    value: stats.totalDurationFormatted,
+                    icon: "clock.fill",
+                    color: .green
+                )
+                StatCard(
+                    title: String(localized: "编辑率"),
+                    value: String(format: "%.1f%%", stats.averageEditRate * 100),
+                    icon: "pencil.tip.crop.circle",
+                    color: .orange
+                )
+                StatCard(
+                    title: String(localized: "错误率"),
+                    value: String(format: "%.1f%%", stats.averageErrorRate * 100),
+                    icon: "exclamationmark.triangle.fill",
+                    color: .red
+                )
+            }
         }
-        .frame(maxWidth: .infinity)
+    }
+
+    private func formatCharacterCount(_ count: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: count)) ?? "\(count)"
     }
 }
 
@@ -113,6 +131,8 @@ struct StatCard: View {
             Text(value)
                 .font(.title2)
                 .fontWeight(.semibold)
+                .minimumScaleFactor(0.8)
+                .lineLimit(1)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()

--- a/TalkTests/UsageStatisticsTests.swift
+++ b/TalkTests/UsageStatisticsTests.swift
@@ -154,4 +154,42 @@ struct UsageStatisticsTests {
         #expect(today != nil)
         #expect(abs((today?.averageSessionDuration ?? 0) - 10) < 0.001)
     }
+
+    @Test("recordSession accumulates totalCharacters")
+    func recordSessionAccumulatesCharacters() async throws {
+        let manager = freshManager()
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 50, hadError: false
+        )
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 30, hadError: false
+        )
+        #expect(manager.dailyStats.first?.totalCharacters == 80)
+    }
+
+    @Test("recordSession with error contributes 0 characters")
+    func recordSessionErrorZeroCharacters() async throws {
+        let manager = freshManager()
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 50, hadError: false
+        )
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 0, hadError: true
+        )
+        #expect(manager.dailyStats.first?.totalCharacters == 50)
+    }
+
+    @Test("backward compatible decoding without totalCharacters")
+    func backwardCompatibleDecoding() async throws {
+        let json = """
+        [{"id":"00000000-0000-0000-0000-000000000001","date":739545600,"sessionCount":1,"totalRecordingDuration":10,"totalProcessingTime":5,"asrInferenceTime":2,"llmInferenceTime":3,"editCount":0,"errorCount":0}]
+        """.data(using: .utf8)!
+        let stats = try JSONDecoder().decode([DailyStats].self, from: json)
+        #expect(stats.first?.totalCharacters == 0)
+        #expect(stats.first?.sessionCount == 1)
+    }
 }

--- a/TalkTests/UsageStatisticsTests.swift
+++ b/TalkTests/UsageStatisticsTests.swift
@@ -183,6 +183,72 @@ struct UsageStatisticsTests {
         #expect(manager.dailyStats.first?.totalCharacters == 50)
     }
 
+    @Test("getAggregateStats includes totalCharacters")
+    func aggregateStatsTotalCharacters() async throws {
+        let manager = freshManager()
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 100, hadError: false
+        )
+        manager.recordSession(
+            recordingDuration: 20, processingTime: 10,
+            asrTime: 4, llmTime: 6, characterCount: 200, hadError: false
+        )
+        let agg = manager.getAggregateStats()
+        #expect(agg.totalCharacters == 300)
+    }
+
+    @Test("estimatedTimeSaved = typingTime - recordingDuration")
+    func estimatedTimeSavedCalculation() async throws {
+        let manager = freshManager()
+        // 200 chars at 100 chars/min = 120s typing time
+        // Recording duration = 30s
+        // Expected saved time = 120 - 30 = 90s
+        manager.recordSession(
+            recordingDuration: 30, processingTime: 10,
+            asrTime: 2, llmTime: 3, characterCount: 200, hadError: false
+        )
+        let agg = manager.getAggregateStats()
+        #expect(abs(agg.estimatedTimeSaved - 90.0) < 0.001)
+    }
+
+    @Test("estimatedTimeSaved clamped to 0 for short inputs")
+    func estimatedTimeSavedClampedToZero() async throws {
+        let manager = freshManager()
+        // 5 chars at 100 chars/min = 3s typing time
+        // Recording duration = 10s
+        // Would be negative, clamp to 0
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 5, hadError: false
+        )
+        let agg = manager.getAggregateStats()
+        #expect(agg.estimatedTimeSaved == 0)
+    }
+
+    @Test("estimatedTimeSavedFormatted shows hours and minutes")
+    func estimatedTimeSavedFormatted() async throws {
+        let manager = freshManager()
+        // 10000 chars at 100 chars/min = 6000s = 100min = 1h40min
+        // Recording = 10s
+        // Saved = 5990s ≈ 1h39min (5990/3600=1, 5990%3600/60=39)
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 10000, hadError: false
+        )
+        let agg = manager.getAggregateStats()
+        #expect(agg.estimatedTimeSavedFormatted.contains("1"))
+        #expect(agg.estimatedTimeSavedFormatted.contains("39"))
+    }
+
+    @Test("estimatedTimeSaved is 0 when totalCharacters is 0")
+    func estimatedTimeSavedWithZeroCharacters() async throws {
+        let manager = freshManager()
+        // No sessions recorded — totalCharacters is 0
+        let agg = manager.getAggregateStats()
+        #expect(agg.estimatedTimeSaved == 0)
+    }
+
     @Test("backward compatible decoding without totalCharacters")
     func backwardCompatibleDecoding() async throws {
         let json = """


### PR DESCRIPTION
## Summary
- Add `totalCharacters` field to `DailyStats` and `recordSession`, tracking per-session character counts
- Pass `characterCount` at all call sites (ASR-only and LLM-polished sessions)
- Add `timeSaved` computation to `AggregateStats` (estimates time saved via typing speed formula)
- Add "Total Characters" and "Time Saved" cards to the Statistics overview UI
- Add 104 lines of unit tests covering all new functionality

## Test plan
- [x] Unit tests pass (`make test`)
- [ ] Verify Statistics UI shows new cards correctly
- [ ] Confirm character counts accumulate across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)