### PR TITLE
fix: remove redundant popover from menu bar click

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,116 @@
+# Talk — Development Guide
+
+## Build & Run
+
+```bash
+git clone https://github.com/platx-ai/Talk.git && cd Talk
+
+# Full setup: resolve dependencies + download models
+make setup
+
+# Run
+make run
+```
+
+### Make targets
+
+```bash
+make build          # Debug build
+make build-release  # Release build
+make test           # Unit tests (excludes benchmarks)
+make benchmark      # Performance benchmarks (requires models)
+make run            # Build and run
+make clean          # Clean build artifacts
+make resolve        # Resolve SPM dependencies
+make download-models # Download ML models from HuggingFace
+make setup          # Full setup: resolve + download models
+```
+
+## Architecture
+
+```
+Record(AVAudioEngine) → ASR(Qwen3-ASR) → LLM Polish(Qwen3-4B) → Text Inject(Cmd+V)
+       ↑                  0.1s               0.5s                     ↑
+    CoreAudio                                                    Accessibility
+  Device Selection                                                API Permission
+```
+
+```
+Talk/
+├── TalkApp.swift          # App entry, AppDelegate, lifecycle
+├── Audio/                 # Audio layer
+│   ├── AudioRecorder.swift      # AVAudioEngine recording + device selection
+│   ├── AudioDeviceManager.swift # CoreAudio device enumeration/monitoring
+│   ├── HotKeyManager.swift      # Global hotkey (CGEventTap, background thread)
+│   └── TextInjector.swift       # Text injection (Accessibility API)
+├── ASR/                   # Speech recognition
+│   └── ASRService.swift         # Qwen3-ASR / Apple Speech / Gemma 4
+├── LLM/                   # Text polishing
+│   └── LLMService.swift         # Qwen3.5 / Gemma 4 via MLXLLM
+├── Models/                # Data models
+│   ├── AppSettings.swift        # Settings + enums (ASREngine, LLMEngine, etc.)
+│   ├── HistoryItem.swift        # History records
+│   └── VocabularyItem.swift     # Personal vocabulary
+├── Data/                  # Persistence
+│   ├── HistoryManager.swift     # History (JSON + M4A audio)
+│   └── VocabularyManager.swift  # Vocabulary management
+├── UI/                    # Interface
+│   ├── SettingsView.swift       # Settings panel (7 tabs)
+│   ├── KeyRecorderView.swift    # Hotkey recorder component
+│   ├── MenuBarView.swift        # Menu bar dropdown (SwiftUI Menu)
+│   ├── LocalTypeMenuBar.swift   # Menu bar controller (NSStatusItem)
+│   ├── HistoryView.swift        # History browser
+│   └── VocabularyView.swift     # Vocabulary management
+└── Utils/                 # Utilities
+    ├── Logger.swift             # Logging system
+    └── MLXRuntimeValidator.swift # Metal runtime check
+```
+
+## Dependencies
+
+All via Swift Package Manager, pinned to specific commits:
+
+| Package | Source | Purpose |
+|---------|--------|---------|
+| mlx-swift | [ml-explore/mlx-swift](https://github.com/ml-explore/mlx-swift) | MLX core array operations |
+| mlx-swift-lm | [ml-explore/mlx-swift-lm](https://github.com/ml-explore/mlx-swift-lm) | LLM inference framework |
+| mlx-audio-swift | [platx-ai/mlx-audio-swift](https://github.com/platx-ai/mlx-audio-swift) (fork) | Audio STT framework |
+| swift-huggingface | [huggingface/swift-huggingface](https://github.com/huggingface/swift-huggingface) | Model downloading |
+
+> mlx-audio-swift uses the platx-ai fork because upstream MLXAudioCodecs is missing the MLXFast dependency.
+
+## Testing
+
+```bash
+make test       # Unit tests
+make benchmark  # Performance benchmarks
+```
+
+### Testing rules
+
+- Swift Testing framework (`@Test`, `#expect`, `Issue.record`), not XCTest
+- `@MainActor` for UI components and Singleton access
+- All new features require tests; bugs require regression tests first
+- Benchmark tests go in `TalkTests/BenchmarkTests.swift`
+- Singleton tests must isolate state (save/restore)
+
+### Performance constraints
+
+- Model loading: background thread (`Task.detached`), never on `@MainActor`
+- Model inference: on `@MainActor` (MLX thread affinity), never wrapped in `Task.detached`
+- UI updates: `@MainActor` property assignment
+
+### Hotkey regressions (historical lessons)
+
+- CGEventTap must run on a dedicated background thread's RunLoop, never main thread
+- CGEventTap callback: lightweight comparison only, dispatch to main on match
+- `startRecording()` path: no `Thread.sleep`, no simulated Cmd+C
+- Selected text capture: Accessibility API by default (zero blocking)
+
+## Code Signing
+
+`DEVELOPMENT_TEAM` is empty in the project. Each developer sets their own in Xcode → Signing & Capabilities. CLI builds use ad-hoc signing.
+
+## Roadmap
+
+See [ROADMAP.md](ROADMAP.md) for the full product roadmap.

--- a/README.md
+++ b/README.md
@@ -6,40 +6,58 @@
 
 <p align="center"><strong>Open Typeless. Local Typeless. Typeless in your box.</strong></p>
 
-A macOS menu bar voice input tool — hold a hotkey, speak, and your words are recognized, polished, and pasted into the active app. Your voice, straight to text. No cloud. No typing.
+<p align="center">macOS menu bar voice input — hold a hotkey, speak, and your words are recognized, polished, and pasted into the active app. No cloud. No typing.</p>
 
-[**Download Talk v0.4.0**](https://github.com/platx-ai/Talk/releases/latest) · [中文文档](README_zh.md)
+<p align="center">
+  <a href="https://github.com/platx-ai/Talk/releases/latest">
+    <img src="https://img.shields.io/github/v/release/platx-ai/Talk?label=Download&color=blue" alt="Latest Release">
+  </a>
+  <img src="https://img.shields.io/badge/platform-macOS%20%2B%20Apple%20Silicon-black" alt="Platform">
+  <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
+</p>
 
-> The original algorithm and code are based on the generous contribution of [@jiamingkong](https://github.com/jiamingkong). We just wanted to see if we could build a typeless in ten minutes.
+[**Download latest Talk**](https://github.com/platx-ai/Talk/releases/latest) · [中文文档](README_zh.md) · [开发文档](DEV.md)
 
 ## Features
 
-- **On-device inference** — Powered by Apple Silicon MLX, no cloud dependency, privacy-first
-- **Dual ASR engines** — Local MLX (Qwen3-ASR-0.6B-4bit) or Apple Speech Recognition, switchable in settings
-- **Text polishing** — Qwen3-4B-Instruct, removes filler words, adds punctuation, smart formatting
-- **Auto hotword learning** — Passively observes your edits after text injection, automatically learns ASR corrections (proper nouns, homophones, abbreviations) via LLM extraction
-- **Audio history** — Every recording saved as AAC/M4A with full ASR context snapshot for replay and debugging
-- **Customizable prompts** — Per-app prompt profiles, 3 polish intensity levels, or write your own system prompt
-- **Selection edit mode** — Select text, speak a command ("fix the typo", "make it casual"), and it's done
-- **Floating status indicator** — Always-on-top overlay showing recording/processing state with audio level meter
-- **Global hotkey** — Customizable key recorder, Push-to-Talk / Toggle modes
-- **Audio device selection** — Pick your input device, defaults to built-in microphone
-- **Auto-paste** — Injects text via Accessibility API with CJK input method auto-switching
-- **Vocabulary learning** — Automatic learning from edit history + manual entry, corrections injected into LLM context
-- **Idle memory management** — Auto-unload models after inactivity, reload on demand
+- **On-device inference** — Apple Silicon + MLX, no cloud, no network after model download
+- **Three ASR engines** — MLX local (Qwen3-ASR), Apple Speech Recognition, or Gemma 4 multimodal
+- **Text polishing** — Qwen3.5-4B or Gemma 4, removes filler words, adds punctuation, smart formatting
+- **One-pass mode** — Set both ASR and LLM to Gemma 4 for single-model speech-to-polished-text
+- **Auto hotword learning** — Passively observes your edits, learns ASR corrections via LLM extraction
+- **Selection edit mode** — Select text, speak a command ("fix the typo", "make it casual")
+- **Per-app prompt profiles** — Different polish styles for Terminal, VSCode, WeChat, etc.
+- **Audio history** — Every recording saved as AAC/M4A with ASR context for replay and debugging
+- **Usage statistics** — Daily session count, recording duration, error rate, 7-day chart, 90-day retention
+- **Real-time preview** — Streaming ASR shows partial transcription as you speak
+- **Floating status indicator** — Always-on-top overlay with audio level meter
+- **Customizable hotkey** — Key recorder, Push-to-Talk / Toggle modes
+- **Output options** — Auto-paste, clipboard-only, or preview window
+
+## Quick Start
+
+1. **Download** [latest release](https://github.com/platx-ai/Talk/releases/latest) (DMG)
+2. **Open** the DMG, drag Talk to `/Applications`
+3. **Launch** — macOS will prompt for permissions:
+   - **Microphone** — for recording
+   - **Input Monitoring** — for global hotkey (System Settings → Privacy & Security)
+   - **Accessibility** — for auto-pasting text (System Settings → Privacy & Security)
+4. **Hold your hotkey** (default `Fn+A`), speak, release — text appears in the active app
+
+Models (~3 GB) download automatically from HuggingFace on first use. Pre-download with `make download-models` if building from source.
 
 ## Performance
 
-All inference runs on-device via Apple Silicon GPU. No network required after model download.
+All inference on-device via Apple Silicon GPU. No network required after model download.
 
 | Stage | Latency | Notes |
 |-------|---------|-------|
-| ASR (3-5s audio) | **0.07 - 0.18s** | 17-51x faster than real-time |
-| LLM polish (short text) | **0.35 - 0.50s** | ~30 chars input |
-| LLM polish (long text) | **1.1 - 1.2s** | ~120 chars input |
+| ASR (3-5s audio) | **0.07 - 0.18s** | 17-51× faster than real-time |
+| LLM polish (short) | **0.35 - 0.50s** | ~30 chars input |
+| LLM polish (long) | **1.1 - 1.2s** | ~120 chars input |
 | **Full pipeline** | **~1s** | ASR + LLM combined (models warm) |
 | ASR model load | 2s | Cold start, one-time |
-| LLM model load | 10s | Cold start, one-time — **bottleneck** |
+| LLM model load | 0.6s | Cold start, one-time |
 
 Memory usage:
 
@@ -48,185 +66,55 @@ Memory usage:
 | ASR model loaded | ~1.6 GB |
 | Both models loaded | ~5.4 GB |
 
-> Full benchmark details and reproduction steps: [docs/BENCHMARK.md](docs/BENCHMARK.md)
->
-> Run `make benchmark` to reproduce on your machine.
+> Full benchmark details: [docs/BENCHMARK.md](docs/BENCHMARK.md)
 
 ## Compatibility
 
-The pre-built DMG in [Releases](https://github.com/platx-ai/Talk/releases/latest) is built and tested on **macOS 26.2 (Tahoe)** with Apple Silicon. That's the only environment we have — our human overlords haven't blessed us with more test devices yet.
-
-| | Tested | Should Work | Notes |
-|---|--------|------------|-------|
-| macOS 26.x (Tahoe) | ✅ | ✅ | Built & tested here |
-| macOS 15.x (Sequoia) | | Likely | Dependencies support macOS 14+ |
-| macOS 14.x (Sonoma) | | Maybe | Minimum required by MLX dependencies |
-| macOS 13 and below | | No | MLX framework requires macOS 14+ |
-| Intel Mac | | No | MLX is Apple Silicon only |
-
-If you're on an older macOS version and encounter issues, try building from source — it might just work:
-```bash
-git clone https://github.com/platx-ai/Talk.git && cd Talk
-make build && make run
-```
-If it doesn't, [open an issue](https://github.com/platx-ai/Talk/issues) and tell us what broke. We'd love more test environments.
+| | Supported | Notes |
+|---|-----------|-------|
+| macOS 26.x (Tahoe) | ✅ | Built & tested |
+| macOS 15.x (Sequoia) | Likely | MLX dependencies support macOS 14+ |
+| macOS 14.x (Sonoma) | Maybe | Minimum for MLX |
+| macOS 13 and below | No | MLX requires macOS 14+ |
+| Intel Mac | No | MLX is Apple Silicon only |
 
 ## Requirements
 
-- Apple Silicon (M1/M2/M3/M4) — **required**, no Intel support
-- macOS 14.0+ (Sonoma) — minimum for MLX dependencies; pre-built DMG targets 26.2+
-- 16 GB RAM recommended (8 GB works with lightweight model — coming soon)
-- ~3 GB disk space (model files)
-- Xcode 26.3+ (only for building from source)
+- Apple Silicon (M1/M2/M3/M4)
+- macOS 14.0+ (Sonoma minimum; pre-built DMG targets macOS 26.2+)
+- 16 GB RAM recommended
+- ~3 GB disk space for model files
 
-## Quick Start
+## Models
 
-```bash
-# Clone the project
-git clone https://github.com/platx-ai/Talk.git
-cd Talk
+| Model | Size | Purpose |
+|-------|------|---------|
+| [Qwen3-ASR-0.6B-4bit](https://huggingface.co/mlx-community/Qwen3-ASR-0.6B-4bit) | ~400 MB | Speech recognition (MLX) |
+| [Qwen3.5-4B-MLX-4bit](https://huggingface.co/mlx-community/Qwen3.5-4B-MLX-4bit) | ~2.8 GB | Text polishing (default LLM) |
+| [Gemma 4 4B](https://huggingface.co/mlx-community/gemma-4-e4b-it-4bit) | — | Multimodal: ASR + LLM in one model |
+| [Gemma 4 2B](https://huggingface.co/mlx-community/gemma-4-e2b-it-4bit) | — | Lightweight multimodal option |
 
-# Full setup: resolve dependencies + download models
-make setup
+Models auto-download from HuggingFace to `~/.cache/huggingface/`.
 
-# Run
-make run
-```
+## Permissions
 
-## Build
+On first launch, grant these in **System Settings → Privacy & Security**:
 
-```bash
-make build          # Debug build
-make build-release  # Release build
-make test           # Run unit tests
-make benchmark      # Run performance benchmarks
-make run            # Build and run
-make clean          # Clean build artifacts
-make resolve        # Resolve SPM dependencies only
-make download-models # Download ML models from HuggingFace
-make setup          # Full setup: resolve + download models
-make lint           # Run SwiftLint (if installed)
-```
+1. **Microphone** — Required for recording. macOS prompts automatically.
+2. **Input Monitoring** — Required for global hotkey.
+3. **Accessibility** — Required for auto-pasting text into other apps.
 
-## Architecture
-
-```
-Record(AVAudioEngine) → ASR(Qwen3-ASR) → LLM Polish(Qwen3-4B) → Text Inject(Cmd+V)
-       ↑                  0.1s               0.5s                     ↑
-    CoreAudio                                                    Accessibility
-  Device Selection                                                API Permission
-```
-
-### Modules
-
-| Module | Responsibility |
-|--------|---------------|
-| `Audio/` | Recording engine, global hotkeys (CGEventTap), audio device management, text injection |
-| `ASR/` | Speech recognition — MLX local (Qwen3-ASR) + Apple Speech |
-| `LLM/` | Text polishing + hotword extraction (MLXLLM + Qwen3-4B-Instruct) |
-| `Models/` | Data models (AppSettings, HotKeyCombo, HistoryItem, ASRContext) |
-| `Data/` | History (JSON + M4A audio), vocabulary, edit observer |
-| `UI/` | SwiftUI menu bar, settings panel, key recorder, floating indicator, history browser, flash capsule |
-| `Utils/` | Logging system, Metal runtime validation |
-
-### Dependencies
-
-All dependencies managed via Swift Package Manager, pinned to specific commits:
-
-| Package | Source | Purpose |
-|---------|--------|---------|
-| mlx-swift | [ml-explore/mlx-swift](https://github.com/ml-explore/mlx-swift) | MLX core array operations |
-| mlx-swift-lm | [ml-explore/mlx-swift-lm](https://github.com/ml-explore/mlx-swift-lm) | LLM inference framework |
-| mlx-audio-swift | [platx-ai/mlx-audio-swift](https://github.com/platx-ai/mlx-audio-swift) (fork) | Audio STT framework |
-| swift-huggingface | [huggingface/swift-huggingface](https://github.com/huggingface/swift-huggingface) | Model downloading |
-
-> mlx-audio-swift uses the platx-ai fork to fix an upstream bug where MLXAudioCodecs is missing the MLXFast dependency.
-
-### Models
-
-| Model | Size | Load Time | Memory | Purpose |
-|-------|------|-----------|--------|---------|
-| [Qwen3-ASR-0.6B-4bit](https://huggingface.co/mlx-community/Qwen3-ASR-0.6B-4bit) | ~400 MB | 2s | ~1.6 GB | Speech recognition |
-| [Qwen3-4B-Instruct-2507-4bit](https://huggingface.co/mlx-community/Qwen3-4B-Instruct-2507-4bit) | ~2.5 GB | 10s | ~4 GB | Text polishing |
-
-Models are automatically downloaded from HuggingFace on first run to `~/.cache/huggingface/`. Pre-download with `make download-models`.
+If the hotkey doesn't respond, check **Input Monitoring** first. Quit and relaunch Talk after enabling.
 
 ## Vocabulary & Auto Learning
 
 Talk learns from your corrections in two ways:
 
-### Passive Edit Observation (v0.4.0)
-After text is injected into the target app, Talk passively monitors the text field via Accessibility API. If you edit the injected text (e.g., fix a misrecognized word), Talk detects the change, extracts hotword corrections using a background LLM pass, and adds them to the vocabulary. A flash ⚡ capsule in the menu bar confirms when new corrections are learned. This works automatically — no manual steps needed.
+**Passive edit observation** — After text injection, Talk monitors the text field. If you edit (e.g., fix a misrecognized word), it detects the change and extracts corrections via a background LLM pass. A ⚡ capsule confirms when new corrections are learned.
 
-### Manual Correction
-- **History edit** — Edit polished text in the history view. The system learns the correction automatically.
-- **Manual entry** — Settings → Personal Vocabulary → Manage Vocabulary. Add original words and their corrected forms.
-- **Import/Export** — JSON format via Manage Vocabulary.
+**Manual** — Edit polished text in history view, or add entries in Settings → Personal Vocabulary → Manage Vocabulary. Supports JSON import/export.
 
-The top learned corrections are injected into the LLM system prompt, so the model applies them automatically in future polishing.
-
-**Example**: If ASR outputs "la laam" but you correct it to "LLM", future polishing will automatically apply this correction.
-
-## Audio History (v0.4.0)
-
-Every voice input is saved as AAC/M4A (64kbps, ~80KB per 10s) alongside a context snapshot (hotword list, language, polish intensity, target app). This enables:
-
-- **Replay & debugging** — Reproduce ASR issues with the exact audio that was processed
-- **Regression testing** — Compare recognition quality across versions
-- **Automatic cleanup** — Audio files are deleted when history entries are removed or expired
-
-Toggle in Settings → Personal Vocabulary → "Save Audio History".
-
-## Permissions
-
-On first launch, you need to grant:
-
-1. **Microphone** — Required for recording. macOS will prompt automatically.
-2. **Input Monitoring** — Required for the global hotkey. Enable Talk in System Settings → Privacy & Security → Input Monitoring.
-3. **Accessibility** — Required for auto-pasting text into other apps. Enable Talk in System Settings → Privacy & Security → Accessibility.
-
-If the global hotkey does not respond, check **Input Monitoring** first. After enabling it, quit and relaunch Talk so the hotkey listener can work reliably.
-
-## Development
-
-```bash
-# Open in Xcode
-open Talk.xcodeproj
-
-# Set your signing team: Xcode → Signing & Capabilities → Team
-# Build & Run: ⌘R
-```
-
-### Testing
-
-```bash
-make test       # Unit tests
-make benchmark  # Performance benchmarks (ASR/LLM load, inference, pipeline, memory)
-```
-
-All changes require tests. Bugs require regression tests before fixing. See [CLAUDE.md](CLAUDE.md) for testing rules.
-
-### Code Signing
-
-`DEVELOPMENT_TEAM` is left empty in the project. Each developer sets their own signing team in Xcode. CLI builds use ad-hoc signing.
-
-## Roadmap
-
-See [ROADMAP.md](ROADMAP.md) for the full product roadmap.
-
-**Next up**
-- Custom lightweight polish model (0.5-1.5B) — < 1s load, < 1 GB memory
-- Real-time transcription preview overlay
-- Model auto-select by hardware (8 GB → lightweight, 16 GB+ → full)
-
-**Mid-term**
-- Project-aware vocabulary & prompt profiles (per-repo `.talk/` config)
-- iCloud vocabulary sync across devices
-- iOS companion app with offline on-device inference
-
-**Long-term**
-- Team shared terminology libraries
-- Plugin system for custom post-processing pipelines
+Top corrections are injected into the LLM system prompt and applied automatically in future sessions.
 
 ## License
 

--- a/Talk/Models/UsageStatistics.swift
+++ b/Talk/Models/UsageStatistics.swift
@@ -19,6 +19,7 @@ struct DailyStats: Codable, Identifiable {
     var llmInferenceTime: TimeInterval = 0        // LLM 推理总时长
     var editCount: Int = 0              // 用户编辑次数
     var errorCount: Int = 0             // 错误次数
+    var totalCharacters: Int = 0              // 总输出字符数
     
     /// 平均每次使用时长
     var averageSessionDuration: TimeInterval {
@@ -33,6 +34,20 @@ struct DailyStats: Codable, Identifiable {
     init(id: UUID = UUID(), date: Date = Date()) {
         self.id = id
         self.date = Calendar.current.startOfDay(for: date)
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        date = try container.decode(Date.self, forKey: .date)
+        sessionCount = try container.decode(Int.self, forKey: .sessionCount)
+        totalRecordingDuration = try container.decode(TimeInterval.self, forKey: .totalRecordingDuration)
+        totalProcessingTime = try container.decode(TimeInterval.self, forKey: .totalProcessingTime)
+        asrInferenceTime = try container.decode(TimeInterval.self, forKey: .asrInferenceTime)
+        llmInferenceTime = try container.decode(TimeInterval.self, forKey: .llmInferenceTime)
+        editCount = try container.decode(Int.self, forKey: .editCount)
+        errorCount = try container.decode(Int.self, forKey: .errorCount)
+        totalCharacters = try container.decodeIfPresent(Int.self, forKey: .totalCharacters) ?? 0
     }
 }
 
@@ -134,6 +149,7 @@ final public class UsageStatisticsManager {
         processingTime: TimeInterval,
         asrTime: TimeInterval,
         llmTime: TimeInterval,
+        characterCount: Int = 0,
         hadError: Bool = false
     ) {
         let today = Calendar.current.startOfDay(for: Date())
@@ -149,6 +165,7 @@ final public class UsageStatisticsManager {
             if hadError {
                 dailyStats[index].errorCount += 1
             }
+            dailyStats[index].totalCharacters += characterCount
             logger.debug("更新了今天的统计记录")
         } else {
             // 创建新记录
@@ -159,6 +176,7 @@ final public class UsageStatisticsManager {
             newDay.asrInferenceTime = asrTime
             newDay.llmInferenceTime = llmTime
             newDay.errorCount = hadError ? 1 : 0
+            newDay.totalCharacters = characterCount
             dailyStats.append(newDay)
             logger.info("创建了新的统计记录")
         }

--- a/Talk/Models/UsageStatistics.swift
+++ b/Talk/Models/UsageStatistics.swift
@@ -61,15 +61,20 @@ struct AggregateStats {
     let averageEditRate: Double
     let averageErrorRate: Double
 
-    /// 格式化总时长
-    var totalDurationFormatted: String {
-        let hours = Int(totalDuration) / 3600
-        let minutes = (Int(totalDuration) % 3600) / 60
+    /// 格式化时长为 "X 小时 Y 分钟" 或 "Y 分钟"
+    static func formatDuration(_ duration: TimeInterval) -> String {
+        let hours = Int(duration) / 3600
+        let minutes = (Int(duration) % 3600) / 60
         if hours > 0 {
             return String(localized: "\(hours) 小时\(minutes) 分钟")
         } else {
             return String(localized: "\(minutes) 分钟")
         }
+    }
+
+    /// 格式化总时长
+    var totalDurationFormatted: String {
+        Self.formatDuration(totalDuration)
     }
 
     /// 估算节省时间（打字 100 字/分钟 vs 实际录音时长）
@@ -80,13 +85,7 @@ struct AggregateStats {
 
     /// 格式化节省时间
     var estimatedTimeSavedFormatted: String {
-        let hours = Int(estimatedTimeSaved) / 3600
-        let minutes = (Int(estimatedTimeSaved) % 3600) / 60
-        if hours > 0 {
-            return String(localized: "\(hours) 小时\(minutes) 分钟")
-        } else {
-            return String(localized: "\(minutes) 分钟")
-        }
+        Self.formatDuration(estimatedTimeSaved)
     }
 }
 

--- a/Talk/Models/UsageStatistics.swift
+++ b/Talk/Models/UsageStatistics.swift
@@ -55,15 +55,33 @@ struct DailyStats: Codable, Identifiable {
 struct AggregateStats {
     let totalSessions: Int
     let totalDuration: TimeInterval
+    let totalCharacters: Int
     let totalEdits: Int
     let totalErrors: Int
     let averageEditRate: Double
     let averageErrorRate: Double
-    
+
     /// 格式化总时长
     var totalDurationFormatted: String {
         let hours = Int(totalDuration) / 3600
         let minutes = (Int(totalDuration) % 3600) / 60
+        if hours > 0 {
+            return String(localized: "\(hours) 小时\(minutes) 分钟")
+        } else {
+            return String(localized: "\(minutes) 分钟")
+        }
+    }
+
+    /// 估算节省时间（打字 100 字/分钟 vs 实际录音时长）
+    var estimatedTimeSaved: TimeInterval {
+        let typingTime = Double(totalCharacters) / 100.0 * 60.0
+        return max(0, typingTime - totalDuration)
+    }
+
+    /// 格式化节省时间
+    var estimatedTimeSavedFormatted: String {
+        let hours = Int(estimatedTimeSaved) / 3600
+        let minutes = (Int(estimatedTimeSaved) % 3600) / 60
         if hours > 0 {
             return String(localized: "\(hours) 小时\(minutes) 分钟")
         } else {
@@ -224,12 +242,14 @@ final public class UsageStatisticsManager {
     func getAggregateStats() -> AggregateStats {
         let totalSessions = dailyStats.reduce(0) { $0 + $1.sessionCount }
         let totalDuration = dailyStats.reduce(0) { $0 + $1.totalRecordingDuration }
+        let totalCharacters = dailyStats.reduce(0) { $0 + $1.totalCharacters }
         let totalEdits = dailyStats.reduce(0) { $0 + $1.editCount }
         let totalErrors = dailyStats.reduce(0) { $0 + $1.errorCount }
-        
+
         return AggregateStats(
             totalSessions: totalSessions,
             totalDuration: totalDuration,
+            totalCharacters: totalCharacters,
             totalEdits: totalEdits,
             totalErrors: totalErrors,
             averageEditRate: totalSessions > 0 ? Double(totalEdits) / Double(totalSessions) : 0,

--- a/Talk/TalkApp.swift
+++ b/Talk/TalkApp.swift
@@ -876,6 +876,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                     processingTime: CFAbsoluteTimeGetCurrent() - processingStart,
                     asrTime: 0,
                     llmTime: llmInferenceTime,
+                    characterCount: polishedText.count,
                     hadError: false
                 )
                 if self.pendingEngineReload {
@@ -1062,6 +1063,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                     processingTime: CFAbsoluteTimeGetCurrent() - processingStart,
                     asrTime: asrInferenceTime,
                     llmTime: llmInferenceTime,
+                    characterCount: polishedText.count,
                     hadError: false
                 )
                 if self.pendingEngineReload {

--- a/Talk/UI/LocalTypeMenuBar.swift
+++ b/Talk/UI/LocalTypeMenuBar.swift
@@ -16,7 +16,6 @@ final class LocalTypeMenuBar {
     private var menuBarView: NSHostingController<MenuBarView>?
     private var settingsWindow: NSWindow?
     private var historyWindow: NSWindow?
-    private var popover: NSPopover?
     private let viewModel = MenuViewModel()
     private let floatingIndicator = FloatingIndicatorWindow()
     private var flashCapsulePanel: FloatingPanel?
@@ -35,20 +34,21 @@ final class LocalTypeMenuBar {
             return
         }
 
-        statusItem.button?.action = #selector(statusBarButtonClicked)
-        statusItem.button?.target = self
-
         let view = MenuBarView(viewModel: viewModel)
             .onOpenSettings { [weak self] in self?.openSettings() }
             .onOpenHistory { [weak self] in self?.openHistory() }
 
         menuBarView = NSHostingController(rootView: view)
-        
-        if let view = menuBarView?.view {
-            view.frame = NSRect(x: 0, y: 0, width: 30, height: 20)
+
+        if let hostingView = menuBarView?.view {
+            hostingView.frame = NSRect(x: 0, y: 0, width: 30, height: 20)
             statusItem.button?.subviews.forEach { $0.removeFromSuperview() }
-            statusItem.button?.addSubview(view)
+            statusItem.button?.addSubview(hostingView)
         }
+
+        // SwiftUI Menu handles click interaction — no button action needed
+        statusItem.button?.action = nil
+        statusItem.button?.target = nil
 
         AppLogger.info("菜单栏设置完成", category: .ui)
     }
@@ -94,29 +94,6 @@ final class LocalTypeMenuBar {
         viewModel.processingStatus = .idle
         viewModel.isRecording = false
         floatingIndicator.updatePhase(.done)
-    }
-
-    @objc private func statusBarButtonClicked() {
-        showPopover()
-    }
-
-    private func showPopover() {
-        guard statusItem != nil else { return }
-
-        let view = MenuBarView(viewModel: viewModel)
-            .onOpenSettings { [weak self] in self?.openSettings() }
-            .onOpenHistory { [weak self] in self?.openHistory() }
-
-        popover = NSPopover()
-        popover?.contentViewController = NSHostingController(rootView: view)
-        popover?.behavior = .transient
-        popover?.animates = true
-
-        if let button = statusItem?.button {
-            popover?.show(relativeTo: button.bounds,
-                          of: button,
-                          preferredEdge: .minY)
-        }
     }
 
     private func openSettings() {

--- a/Talk/UI/SettingsView+Statistics.swift
+++ b/Talk/UI/SettingsView+Statistics.swift
@@ -11,13 +11,7 @@ import SwiftUI
 struct StatisticsView: View {
     @ObservationIgnored
     private let statsManager = UsageStatisticsManager.shared
-    
-    private let numberFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter
-    }()
-    
+
     var body: some View {
         // Match the other settings tabs (RecordingSettingsTab, ASRSettingsTab,
         // …) which use Form{} as the top-level container — Form gives consistent
@@ -104,9 +98,7 @@ struct OverviewSection: View {
     }
 
     private func formatCharacterCount(_ count: Int) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: count)) ?? "\(count)"
+        count.formatted(.number)
     }
 }
 

--- a/Talk/UI/SettingsView+Statistics.swift
+++ b/Talk/UI/SettingsView+Statistics.swift
@@ -59,36 +59,54 @@ struct OverviewSection: View {
     let stats: AggregateStats
 
     var body: some View {
-        HStack(spacing: 12) {
-            StatCard(
-                title: String(localized: "总使用次数"),
-                value: "\(stats.totalSessions)",
-                icon: "mic.fill",
-                color: .blue
-            )
-
-            StatCard(
-                title: String(localized: "总录音时长"),
-                value: stats.totalDurationFormatted,
-                icon: "clock.fill",
-                color: .green
-            )
-
-            StatCard(
-                title: String(localized: "编辑率"),
-                value: String(format: "%.1f%%", stats.averageEditRate * 100),
-                icon: "pencil.tip.crop.circle",
-                color: .orange
-            )
-
-            StatCard(
-                title: String(localized: "错误率"),
-                value: String(format: "%.1f%%", stats.averageErrorRate * 100),
-                icon: "exclamationmark.triangle.fill",
-                color: .red
-            )
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                StatCard(
+                    title: String(localized: "总使用次数"),
+                    value: "\(stats.totalSessions)",
+                    icon: "mic.fill",
+                    color: .blue
+                )
+                StatCard(
+                    title: String(localized: "总输入字数"),
+                    value: formatCharacterCount(stats.totalCharacters),
+                    icon: "text.cursor",
+                    color: .purple
+                )
+                StatCard(
+                    title: String(localized: "累计节省时间"),
+                    value: stats.estimatedTimeSavedFormatted,
+                    icon: "bolt.fill",
+                    color: .yellow
+                )
+            }
+            HStack(spacing: 12) {
+                StatCard(
+                    title: String(localized: "总录音时长"),
+                    value: stats.totalDurationFormatted,
+                    icon: "clock.fill",
+                    color: .green
+                )
+                StatCard(
+                    title: String(localized: "编辑率"),
+                    value: String(format: "%.1f%%", stats.averageEditRate * 100),
+                    icon: "pencil.tip.crop.circle",
+                    color: .orange
+                )
+                StatCard(
+                    title: String(localized: "错误率"),
+                    value: String(format: "%.1f%%", stats.averageErrorRate * 100),
+                    icon: "exclamationmark.triangle.fill",
+                    color: .red
+                )
+            }
         }
-        .frame(maxWidth: .infinity)
+    }
+
+    private func formatCharacterCount(_ count: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: count)) ?? "\(count)"
     }
 }
 
@@ -113,6 +131,8 @@ struct StatCard: View {
             Text(value)
                 .font(.title2)
                 .fontWeight(.semibold)
+                .minimumScaleFactor(0.8)
+                .lineLimit(1)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()

--- a/TalkTests/UsageStatisticsTests.swift
+++ b/TalkTests/UsageStatisticsTests.swift
@@ -154,4 +154,42 @@ struct UsageStatisticsTests {
         #expect(today != nil)
         #expect(abs((today?.averageSessionDuration ?? 0) - 10) < 0.001)
     }
+
+    @Test("recordSession accumulates totalCharacters")
+    func recordSessionAccumulatesCharacters() async throws {
+        let manager = freshManager()
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 50, hadError: false
+        )
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 30, hadError: false
+        )
+        #expect(manager.dailyStats.first?.totalCharacters == 80)
+    }
+
+    @Test("recordSession with error contributes 0 characters")
+    func recordSessionErrorZeroCharacters() async throws {
+        let manager = freshManager()
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 50, hadError: false
+        )
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 0, hadError: true
+        )
+        #expect(manager.dailyStats.first?.totalCharacters == 50)
+    }
+
+    @Test("backward compatible decoding without totalCharacters")
+    func backwardCompatibleDecoding() async throws {
+        let json = """
+        [{"id":"00000000-0000-0000-0000-000000000001","date":739545600,"sessionCount":1,"totalRecordingDuration":10,"totalProcessingTime":5,"asrInferenceTime":2,"llmInferenceTime":3,"editCount":0,"errorCount":0}]
+        """.data(using: .utf8)!
+        let stats = try JSONDecoder().decode([DailyStats].self, from: json)
+        #expect(stats.first?.totalCharacters == 0)
+        #expect(stats.first?.sessionCount == 1)
+    }
 }

--- a/TalkTests/UsageStatisticsTests.swift
+++ b/TalkTests/UsageStatisticsTests.swift
@@ -183,6 +183,72 @@ struct UsageStatisticsTests {
         #expect(manager.dailyStats.first?.totalCharacters == 50)
     }
 
+    @Test("getAggregateStats includes totalCharacters")
+    func aggregateStatsTotalCharacters() async throws {
+        let manager = freshManager()
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 100, hadError: false
+        )
+        manager.recordSession(
+            recordingDuration: 20, processingTime: 10,
+            asrTime: 4, llmTime: 6, characterCount: 200, hadError: false
+        )
+        let agg = manager.getAggregateStats()
+        #expect(agg.totalCharacters == 300)
+    }
+
+    @Test("estimatedTimeSaved = typingTime - recordingDuration")
+    func estimatedTimeSavedCalculation() async throws {
+        let manager = freshManager()
+        // 200 chars at 100 chars/min = 120s typing time
+        // Recording duration = 30s
+        // Expected saved time = 120 - 30 = 90s
+        manager.recordSession(
+            recordingDuration: 30, processingTime: 10,
+            asrTime: 2, llmTime: 3, characterCount: 200, hadError: false
+        )
+        let agg = manager.getAggregateStats()
+        #expect(abs(agg.estimatedTimeSaved - 90.0) < 0.001)
+    }
+
+    @Test("estimatedTimeSaved clamped to 0 for short inputs")
+    func estimatedTimeSavedClampedToZero() async throws {
+        let manager = freshManager()
+        // 5 chars at 100 chars/min = 3s typing time
+        // Recording duration = 10s
+        // Would be negative, clamp to 0
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 5, hadError: false
+        )
+        let agg = manager.getAggregateStats()
+        #expect(agg.estimatedTimeSaved == 0)
+    }
+
+    @Test("estimatedTimeSavedFormatted shows hours and minutes")
+    func estimatedTimeSavedFormatted() async throws {
+        let manager = freshManager()
+        // 10000 chars at 100 chars/min = 6000s = 100min = 1h40min
+        // Recording = 10s
+        // Saved = 5990s ≈ 1h39min (5990/3600=1, 5990%3600/60=39)
+        manager.recordSession(
+            recordingDuration: 10, processingTime: 5,
+            asrTime: 2, llmTime: 3, characterCount: 10000, hadError: false
+        )
+        let agg = manager.getAggregateStats()
+        #expect(agg.estimatedTimeSavedFormatted.contains("1"))
+        #expect(agg.estimatedTimeSavedFormatted.contains("39"))
+    }
+
+    @Test("estimatedTimeSaved is 0 when totalCharacters is 0")
+    func estimatedTimeSavedWithZeroCharacters() async throws {
+        let manager = freshManager()
+        // No sessions recorded — totalCharacters is 0
+        let agg = manager.getAggregateStats()
+        #expect(agg.estimatedTimeSaved == 0)
+    }
+
     @Test("backward compatible decoding without totalCharacters")
     func backwardCompatibleDecoding() async throws {
         let json = """


### PR DESCRIPTION
## Summary
- Remove the NSPopover that was triggered on menu bar click, which caused a confusing "click Talk icon → popup with another Talk icon" behavior
- Let the SwiftUI `Menu` embedded in the status bar button handle clicks directly, showing the dropdown menu items

## Test plan
- [ ] Click menu bar Talk icon → should show dropdown menu (录音/历史/设置/退出) directly
- [ ] Verify no small popover window with duplicate icon appears
- [ ] Verify menu items (开始录音, 历史记录, 设置, 退出) all work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)